### PR TITLE
Pin direct dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.6.1",
-        "playwright": "^1.48.0",
+        "playwright": "1.60.0",
         "zod": "^3.25.0"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.6.1",
+        "@modelcontextprotocol/sdk": "1.29.0",
         "playwright": "1.60.0",
-        "zod": "^3.25.0"
+        "zod": "3.25.76"
       },
       "bin": {
         "ozon-mcp-server": "src/index.js"

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "license": "MIT",
   "engines": { "node": ">=20" },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.6.1",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "playwright": "1.60.0",
-    "zod": "^3.25.0"
+    "zod": "3.25.76"
   }
 }


### PR DESCRIPTION
## Summary

- Pin all direct npm dependencies to exact versions already resolved in `package-lock.json`.
- Keep Playwright pinned at `1.60.0` and align the lockfile root metadata with `package.json`.
- Do not change runtime source, Docker configuration, or resolved dependency versions.

## Why

This is a supply-chain hardening change. Exact direct dependency versions make installs and reviews less vulnerable to unintended semver-range drift, and keep `package.json` aligned with the audited lockfile resolution.

Pinned direct versions:

- `@modelcontextprotocol/sdk`: `1.29.0`
- `playwright`: `1.60.0`
- `zod`: `3.25.76`

## Verification

- Metadata check: package specs match lockfile root metadata and resolved versions for all direct dependencies.
- `npm ci --dry-run --omit=dev`
- `npm run test:parse`